### PR TITLE
Error out with exit instead of return on missing cl args.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 # Check args
 if [ "$#" -ne 1 ]; then
   echo "usage: ./build.sh IMAGE_NAME"
-  return 1
+  exit 1
 fi
 
 # Get this script's path

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 # Check args
 if [ "$#" -ne 1 ]; then
   echo "usage: ./run.sh IMAGE_NAME"
-  return 1
+  exit 1
 fi
 
 # Get this script's path


### PR DESCRIPTION
I don't know whether this is something that is allowed on newer versions of Bash, but at least on Ubuntu Trusty (with `4.3.11(1)-release`) using `return 1` results in:

```
usage: ./build.sh IMAGE_NAME
./build.sh: line 6: return: can only `return' from a function or sourced script
invalid value "." for flag -t: Error parsing reference: "." is not a valid repository/tag
See 'docker build --help'.
```
